### PR TITLE
Added the sqlite-retry-count input.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,7 @@ jobs:
       uses: ./
       with:
         sqlite-version: ${{ matrix.sqlite }}
+        sqlite-retry-count: 10
     - run: sqlite3 --version
 
   # test setup action works with latest version of SQLite
@@ -113,4 +114,6 @@ jobs:
       # use local distribution until we release an official version
       #   ccorsi/setup-sqlite@v1
       uses: ./
+      with:
+        sqlite-retry-count: 10
     - run: sqlite3 --version

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'The url prefix to the SQLite download site without the year and version information, for example, https://www.sqlite.org/'
     required: false
     default: 'https://www.sqlite.org/'
+  sqlite-retry-count:
+    description: 'The retry count for github rest api calls, default 3.  Relevant when not defining version/year input combinations.'
+    required: false
+    default: '3'
 outputs:
   cache-hit:
     description: 'A boolean value to indicate if a cache was hit'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ccorsi/setup-sqlite",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "description": "Setup Action for the sqlite distribution",
   "main": "dist/main.js",
   "scripts": {

--- a/src/setup.js
+++ b/src/setup.js
@@ -28,6 +28,41 @@ const { extractZip, cacheDir, find, downloadTool } = require('@actions/tool-cach
 const { rm, readdir, stat } = require('fs/promises');
 const { sep } = require('path');
 
+// Default retry count used when using the GitHub REST APi.
+const default_retry_count = 3
+
+// for testing purposes export this value to check that the expected result will be set
+// whenever we incorrectly set the retry count
+module.exports.default_retry_count = default_retry_count
+
+/*
+ * This method will return the retry count that will be used whenever we are using the
+ * GitHub REST API.  It will determine if the sqlite-retry-count input was an integer
+ * and greater than one.  If it is, then it will use that value are the retry count.
+ */
+function set_max_retry_count() {
+    let input = core.getInput('sqlite-retry-count')
+    let value = default_retry_count
+
+    if (Number.isInteger(input)) {
+        let v = Number(input)
+        if (v > 0) {
+            core.info(`Setting retry count to ${v}`)
+            value = v
+        } else {
+            core.warning(`An invalid sqlite-retry-count was passed: ${input}, the value has to be greater than 0, defaulting to ${default_retry_count}`)
+        }
+    } else if (input?.length > 0) {
+        core.warning(`An invalid sqlite-retry-count was passed: ${input}, defaulting to ${default_retry_count}`)
+    }
+
+    return value
+}
+
+const max_retry_count = set_max_retry_count()
+
+module.exports.max_retry_count = max_retry_count
+
 /**
  * This method is passed a version in string format that will then be converted into
  * the expect format to be able to append to the download url to retreive the sqlite
@@ -201,7 +236,7 @@ async function executeClientGetCall(client, uri,
             throw new Error(message, { cause })
         }
 
-        if (retryCount == 3) {
+        if (retryCount == max_retry_count) {
             // eat the rest of the input information so that no memory leak will be generated
             res.message.resume()
 

--- a/test/retry.count.test.js
+++ b/test/retry.count.test.js
@@ -11,8 +11,8 @@ const path = require('path')
 // Set test limit to 60 seconds
 jest.setTimeout(60000)
 
-const cachePath = path.join(__dirname, 'CACHE')
-const tempPath =  path.join(__dirname, 'TEMP')
+const cachePath = path.join(__dirname, 'RETRYCOUNT', 'CACHE')
+const tempPath =  path.join(__dirname, 'RETRYCOUNT', 'TEMP')
 
 // Set temp and tool directories before importing (used to set global state)
 process.env['RUNNER_TEMP']       = tempPath

--- a/test/retry.count.test.js
+++ b/test/retry.count.test.js
@@ -57,11 +57,20 @@ function expected(value) {
     }
 }
 
-describe.each([ '1', '0', '-11', 'a', '3', '' ])('.retry-count(%s)', (value) => {
+let input = [
+    [ '1',   '3.48.0', '2025' ],
+    [ '0',   '3.47.2', '2024' ],
+    [ '-11', '3.47.1', '2024' ],
+    [ 'a',   '3.47.0', '2024' ],
+    [ '3',   '3.46.1', '2024' ],
+    [ '',    '3.46.0', '2024' ]
+]
+
+describe.each(input)('.retry-count(%s)', (retry_count, version, year) => {
 
     beforeEach(() => {
         // Set the sqlite-retry-count input to value
-        set_input('sqlite-retry-count', value)
+        set_input('sqlite-retry-count', retry_count)
     })
 
     afterEach(() => {
@@ -69,15 +78,15 @@ describe.each([ '1', '0', '-11', 'a', '3', '' ])('.retry-count(%s)', (value) => 
         set_input('sqlite-retry-count', '')
     })
 
-    test(`.retry-count(${value})`, async () => {
+    test(`.retry-count(${retry_count})`, async () => {
         // Insure that the sqlite-retry-count input was correctly set
-        expect(core.getInput('sqlite-retry-count')).toBe(value)
+        expect(core.getInput('sqlite-retry-count')).toBe(retry_count)
 
         // Execute the setup_sqlite action
-        await execute('3.48.0', '2025', url_prefix)
+        await execute(version, year, url_prefix)
 
         // Check that the max_retry_count was correctly set
-        expect(max_retry_count).toBe(expected(value))
+        expect(max_retry_count).toBe(expected(retry_count))
     })
 
 })

--- a/test/retry.count.test.js
+++ b/test/retry.count.test.js
@@ -1,0 +1,83 @@
+/*
+ * The following set of tests will be testing the different combinations of
+ * setting the retry count for the setup-sqlite action.
+ */
+
+const { setup_sqlite, cleanup, default_retry_count, max_retry_count } = require('../src/setup')
+const core = require('@actions/core')
+const { existsSync, rmSync } = require('fs')
+const path = require('path')
+
+// Set test limit to 60 seconds
+jest.setTimeout(60000)
+
+const cachePath = path.join(__dirname, 'CACHE')
+const tempPath =  path.join(__dirname, 'TEMP')
+
+// Set temp and tool directories before importing (used to set global state)
+process.env['RUNNER_TEMP']       = tempPath
+process.env['RUNNER_TOOL_CACHE'] = cachePath
+
+function cleanup_cache_and_temp() {
+    if (existsSync(cachePath)) {
+        rmSync(cachePath, { recursive: true, force: true })
+    }
+    if (existsSync(tempPath)) {
+        rmSync(tempPath, { recursive: true, force: true })
+    }
+}
+
+// Delete the TEMP and CACHE directory before and/or after executing the tests
+beforeAll(cleanup_cache_and_temp)
+afterAll( cleanup_cache_and_temp)
+
+const url_prefix = 'https://www.sqlite.org/'
+
+async function execute(version, year) {
+   // execute setup_sqlite intallation
+   return setup_sqlite(version, year, url_prefix).finally(
+      // run the cleanup callbacks
+      cleanup
+   )
+}
+
+function set_input(name, value) {
+    process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] = String(value)
+}
+
+function expected(value) {
+    if (Number.isInteger(value)) {
+        value = Number(value)
+        if (value < 0) {
+            return default_retry_count
+        }
+        return value
+    } else {
+        return default_retry_count
+    }
+}
+
+describe.each([ '1', '0', '-11', 'a', '3', '' ])('.retry-count(%s)', (value) => {
+
+    beforeEach(() => {
+        // Set the sqlite-retry-count input to value
+        set_input('sqlite-retry-count', value)
+    })
+
+    afterEach(() => {
+        // Unset the sqlite-retry-count input
+        set_input('sqlite-retry-count', '')
+    })
+
+    test(`.retry-count(${value})`, async () => {
+        // Insure that the sqlite-retry-count input was correctly set
+        expect(core.getInput('sqlite-retry-count')).toBe(value)
+
+        // Execute the setup_sqlite action
+        await execute('3.48.0', '2025', url_prefix)
+
+        // Check that the max_retry_count was correctly set
+        expect(max_retry_count).toBe(expected(value))
+    })
+
+})

--- a/test/setup.monthly.test.js
+++ b/test/setup.monthly.test.js
@@ -11,8 +11,8 @@ const hc = require('@actions/http-client')
 // Set test limit to 60 minutes
 jest.setTimeout(3600000)
 
-const cachePath = path.join(__dirname, 'CACHE')
-const tempPath =  path.join(__dirname, 'TEMP')
+const cachePath = path.join(__dirname, 'MONTHLY', 'CACHE')
+const tempPath =  path.join(__dirname, 'MONTHLY', 'TEMP')
 
 // Set temp and tool directories before importing (used to set global state)
 process.env['RUNNER_TEMP']       = tempPath

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -35,8 +35,8 @@ const distributions = {
 // Set test limit to 60 minutes
 jest.setTimeout(3600000)
 
-const cachePath = path.join(__dirname, 'CACHE')
-const tempPath =  path.join(__dirname, 'TEMP')
+const cachePath = path.join(__dirname, 'SETUP', 'CACHE')
+const tempPath =  path.join(__dirname, 'SETUP', 'TEMP')
 
 // Set temp and tool directories before importing (used to set global state)
 process.env['RUNNER_TEMP']       = tempPath


### PR DESCRIPTION
This pull request includes the addition of the sqlite-retry-count input variable.  The setup-sqlite action recently added the ability to retry any github rest api call.  This implementation defaulted to 3 retries of those rest api calls.  Since, it is possible that you might require more than the default 3 retry count whenever you are performing many different sqlite version installation within your workflow.  Increasing the retry count would allow your tests to be able to complete without incurring failures because the setup-sqlite action exhausted its retry count.

Note that the use of the retry count comes into play whenever you don't explicitly define the sqlite-version and sqlite-year input variables.  Defining the version and year will not require this action to perform any github rest api calls.  It will then directly access the sqlite download file from the sqlite web site.